### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,16 @@
 import 'react-app-polyfill/stable'
 import 'core-js'
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 import reportWebVitals from './reportWebVitals'
 import { Provider } from 'react-redux'
 import store from './store'
 
-ReactDOM.render(
+createRoot(document.getElementById('root')).render(
   <Provider store={store}>
     <App />
   </Provider>,
-  document.getElementById('root'),
 )
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
According to this link : 
 https://reactjs.org/link/switch-to-createroot
"ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it’s running React 17"