### PR TITLE
Fix(sidebar): remove items attribute from li element

### DIFF
--- a/src/components/AppSidebarNav.js
+++ b/src/components/AppSidebarNav.js
@@ -37,7 +37,7 @@ export const AppSidebarNav = ({ items }) => {
     )
   }
   const navGroup = (item, index) => {
-    const { component, name, icon, to, ...rest } = item
+    const { component, name, icon, to, items, ...rest } = item
     const Component = component
     return (
       <Component
@@ -47,8 +47,8 @@ export const AppSidebarNav = ({ items }) => {
         visible={location.pathname.startsWith(to)}
         {...rest}
       >
-        {item.items?.map((item, index) =>
-          item.items ? navGroup(item, index) : navItem(item, index),
+        {items?.map((item, index) =>
+          items ? navGroup(item, index) : navItem(item, index),
         )}
       </Component>
     )

--- a/src/components/AppSidebarNav.test.js
+++ b/src/components/AppSidebarNav.test.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { CNavGroup, CNavItem } from '@coreui/react'
+import { AppSidebarNav } from './AppSidebarNav'
+import { HashRouter, Route, Routes } from 'react-router-dom'
+import { render } from '@testing-library/react'
+
+test('renders nav group without items attribute', () => {
+  const navigation = [
+    {
+      component: CNavGroup,
+      name: 'Base',
+      to: '/base',
+      items: [
+        {
+          component: CNavItem,
+          name: 'Item',
+          to: '/base/item',
+        },
+      ],
+    },
+  ]
+
+  const { container } = render(
+    <HashRouter>
+      <Routes>
+        <Route path="/" element={<AppSidebarNav items={navigation} />} />
+      </Routes>
+    </HashRouter>,
+  )
+
+  /* eslint-disable testing-library/no-container */
+  /* eslint-disable testing-library/no-node-access */
+  const groupElement = container.querySelector('.nav-group')
+  expect(groupElement).toBeInTheDocument()
+  expect(groupElement.hasAttribute('items')).toBeFalsy()
+})


### PR DESCRIPTION
Hello!

Just found this little issue, it is happening right now in your demo:
https://coreui.io/demos/react/4.0/free/#/dashboard

In sidebar navigation, all `li` elements with nested lists look like this (they have extra`items` attribute) 
```html
<li class="nav-group show" items="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"><a class="nav-link nav-group-toggle">
```

I wrote a test for this case, it's not working in the current master branch but works with the fix.
I need to test for attributes that are not visible to user, that's why I did as it said here:
https://testing-library.com/docs/queries/about/#manual-queries

But I was forced to ignore some linter warnings **in the test file** because it was complaining 
```
  30:24  error  Avoid using container methods. Prefer using the methods from Testing Library, such as "getByRole()"  testing-library/no-container
  30:34  error  Avoid direct Node access. Prefer using the methods from Testing Library                              testing-library/no-node-access
  30:34  error  Avoid direct Node access. Prefer using the methods from Testing Library                              testing-library/no-node-access
```
Not the best decision, sorry, but I really wanted to add some tests!
What do you think? What can I do - rewrite the test, delete the test, delete the whole MR?...