### PR TITLE
Security Problem With Process Env

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -4,10 +4,6 @@ import path from 'node:path'
 import autoprefixer from 'autoprefixer'
 
 export default defineConfig(({ mode }) => {
-  // Load .env
-  const env = loadEnv(mode, process.cwd(), '')
-  process.env = { ...process.env, ...env }
-
   return {
     base: './',
     build: {
@@ -19,10 +15,6 @@ export default defineConfig(({ mode }) => {
           autoprefixer({}), // add options if needed
         ],
       },
-    },
-    define: {
-      // vitejs does not support process.env so we have to redefine it
-      'process.env': process.env,
     },
     esbuild: {
       loader: 'jsx',


### PR DESCRIPTION
I have a problema using the current code using process.env in the config file of vite. Actually, the process.env from Node.JS invokes all enviroment variables from the SO. Consequently, when we build the application, we can see all enviroment variables by searching in the **developer tools** of the browser.

**Here's an example**
 
- Creating an password env variable:
![Env Variable Created](https://github.com/coreui/coreui-free-react-admin-template/assets/63265629/5b834556-8b58-495f-81cd-022490b102e2)

- Searching for this variable and others from the SO:
![env exposed](https://github.com/coreui/coreui-free-react-admin-template/assets/63265629/a129c27d-bc08-4674-b3ea-b52d50cddade)

Especially in a CI/CD flow, this is a crucial problem because a host that runs a CI/CD flow can have password env variables in the SO.

To solve this, I just created a `.env` file and use this guidelines provided by VITE to create env variable:  https://vitejs.dev/guide/env-and-mode#env-files

This guidelines specify that we need to create a env with the prefix `VITE` and references like this `console.log(import.meta.env.VITE_SOME_KEY)`


Enviroment:

- Browser: Google Chrome 123.0.6312.58
- SO: Ubuntu 22.04.4 LTS