### PR TITLE
fix stepper url typo in nav

### DIFF
--- a/src/_nav.js
+++ b/src/_nav.js
@@ -354,7 +354,7 @@ const _nav = [
             <CIcon icon={cilExternalLink} size="sm" className="ms-2" />
           </React.Fragment>
         ),
-        href: 'https://coreui.io/react/docs/forms/stepp/',
+        href: 'https://coreui.io/react/docs/forms/stepper/',
         badge: {
           color: 'danger',
           text: 'PRO',


### PR DESCRIPTION
# Fix: Issue 456

Closes #444 
Closes #355 
Closes #329 

## Problem
The Stepper navigation link had a typo in the URL (`stepp/` instead of `stepper/`), causing a 404 error when users clicked the link.

## Solution
Corrected the URL from `stepp/` to `stepper/` to point to the correct documentation page.

## Changes
**Before:**
```javascript
href: '[https://coreui.io/react/docs/forms/stepp/'](https://coreui.io/react/docs/forms/stepp/'),